### PR TITLE
Add 'template' option

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,13 +37,22 @@ function inject(string, obj, regexp) {
 
 module.exports = postcss.plugin(PLUGIN_NAME, opts => {
 	opts = opts || {};
+	if (!('template' in opts)) {
+		opts.template = false;
+	}
 
 	const regexp = generateRegExp(opts.prefix || '$');
 
 	return css => {
 		css.walkDecls(decl => {
 			try {
-				decl.value = inject(decl.value, opts.data, regexp);
+				if (opts.template) {
+					if (!decl.value.match(regexp)) {
+						decl.remove();
+					}
+				} else {
+					decl.value = inject(decl.value, opts.data, regexp);
+				}
 			} catch (err) {
 				throw decl.error(err.message, {plugin: PLUGIN_NAME});
 			}

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,14 @@ Default: `$`
 
 A prefix for variable names. May contain several characters.
 
+##### template
+
+Type: `boolean`  
+Default: `false`
+
+If true, all rules that do not involve variables will be omitted, and variables
+will not be resolved.
+
 
 ## License
 


### PR DESCRIPTION
This PR allows you to compile a base stylesheet with default variables (template=false) and then produce a minimal template file (template=true) which you could convert into, say, a JS template you can run in real time in the browser which only outputs the rules involving variables and is hence small, efficient and performant.
