### PR TITLE
Matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,10 @@ const execall = require('execall');
 
 const PLUGIN_NAME = 'external-vars';
 const ALLOWED_TYPES = ['string', 'number'];
+const CAPTURE_GROUP = '([^)};, ]+)';
 
-function makeRe(prefix) {
-	const capture = '([^)};, ]+)';
-	return new RegExp(escapeString(prefix) + capture, 'g');
+function makeRe(prefix, flags) {
+	return new RegExp(escapeString(prefix) + CAPTURE_GROUP, flags);
 }
 
 function checkProperty(obj, prop) {
@@ -39,7 +39,7 @@ function inject(string, obj, re) {
 const externalVars = postcss.plugin(PLUGIN_NAME, opts => {
 	opts = opts || {};
 
-	const re = makeRe(opts.prefix || '$');
+	const re = makeRe(opts.prefix || '$', 'g');
 
 	return css => {
 		css.walkDecls(decl => {
@@ -52,20 +52,18 @@ const externalVars = postcss.plugin(PLUGIN_NAME, opts => {
 	};
 });
 
-externalVars.test = (str, opts) => {
+externalVars.tester = opts => {
 	opts = opts || {};
 	const re = makeRe(opts.prefix || '$');
 
-	return re.test(str);
+	return str => re.test(str);
 };
 
-externalVars.matches = (str, opts) => {
+externalVars.matcher = opts => {
 	opts = opts || {};
-	const re = makeRe(opts.prefix || '$');
+	const re = makeRe(opts.prefix || '$', 'g');
 
-	return execall(re, str).map(function (res) {
-		return res.sub[0];
-	});
+	return str => execall(re, str).map(res => res.sub[0]);
 };
 
 module.exports = externalVars;

--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 'use strict';
 const postcss = require('postcss');
 const escapeString = require('escape-string-regexp');
+const execall = require('execall');
 
 const PLUGIN_NAME = 'external-vars';
 const ALLOWED_TYPES = ['string', 'number'];
 
 function makeRe(prefix) {
-	const capture = '([^,); ]+)';
+	const capture = '([^)};, ]+)';
 	return new RegExp(escapeString(prefix) + capture, 'g');
 }
 
@@ -35,7 +36,7 @@ function inject(string, obj, re) {
 	return string.replace(re, (match, path) => nestedProperty(obj, path));
 }
 
-module.exports = postcss.plugin(PLUGIN_NAME, opts => {
+const externalVars = postcss.plugin(PLUGIN_NAME, opts => {
 	opts = opts || {};
 
 	const re = makeRe(opts.prefix || '$');
@@ -50,3 +51,21 @@ module.exports = postcss.plugin(PLUGIN_NAME, opts => {
 		});
 	};
 });
+
+externalVars.test = (str, opts) => {
+	opts = opts || {};
+	const re = makeRe(opts.prefix || '$');
+
+	return re.test(str);
+};
+
+externalVars.matches = (str, opts) => {
+	opts = opts || {};
+	const re = makeRe(opts.prefix || '$');
+
+	return execall(re, str).map(function (res) {
+		return res.sub[0];
+	});
+};
+
+module.exports = externalVars;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "dependencies": {
     "escape-string-regexp": "^1.0.4",
+    "execall": "^1.0.0",
     "postcss": "^5.0.14"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -76,16 +76,16 @@ Default: `$`
 A prefix for variable names. May contain several characters.
 
 
-### externalVars.test(string, [opts])
+### externalVars.tester([opts])
 
-Check if the `string` has any variables in it. Returns `boolean`.
+Returns a `function` that will accept `string` to check if it contains any variables and return `boolean`. Useful to filter your css declarations before processing.
 
 [Options](#opts) are the same.
 
 
-### externalVars.matches(string, [opts])
+### externalVars.matcher([opts])
 
-Return an `array` of all the matched variable names within the `string`.
+Returns a `function` that will accept `string` and return an `array` of all the matched variable names within it.
 
 [Options](#opts) are the same.
 

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Check [PostCSS] docs out for examples in your preferred environment.
 
 ## API
 
-### externalVars({opts})
+### externalVars([opts])
 
 #### opts
 
@@ -74,6 +74,20 @@ Type: `string`
 Default: `$`
 
 A prefix for variable names. May contain several characters.
+
+
+### externalVars.test(string, [opts])
+
+Check if the `string` has any variables in it. Returns `boolean`.
+
+[Options](#opts) are the same.
+
+
+### externalVars.matches(string, [opts])
+
+Return an `array` of all the matched variable names within the `string`.
+
+[Options](#opts) are the same.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -1,10 +1,10 @@
 import postcss from 'postcss';
 import test from 'ava';
 
-import plugin from './';
+import fn from './';
 
 function run(t, input, output, opts = {}) {
-	return postcss([plugin(opts)])
+	return postcss([fn(opts)])
 		.process(input)
 		.then(result => {
 			t.same(result.css, output);
@@ -65,3 +65,17 @@ test('custom prefix', t => {
 });
 
 test('no data provided case', t => run(t, 'a {color: #bada55}', 'a {color: #bada55}'));
+
+test('fn.test()', t => {
+	t.true(fn.test('$yo'));
+	t.true(fn.test('!yo', {prefix: '!'}));
+
+	t.false(fn.test('!yo'));
+	t.false(fn.test('$yo', {prefix: '!'}));
+});
+
+test('fn.matches()', t => {
+	const res = fn.matches('$some $stuff');
+
+	t.same(res, ['some', 'stuff']);
+});

--- a/test.js
+++ b/test.js
@@ -66,16 +66,20 @@ test('custom prefix', t => {
 
 test('no data provided case', t => run(t, 'a {color: #bada55}', 'a {color: #bada55}'));
 
-test('fn.test()', t => {
-	t.true(fn.test('$yo'));
-	t.true(fn.test('!yo', {prefix: '!'}));
+test('fn.tester()', t => {
+	const defaultTest = fn.tester();
 
-	t.false(fn.test('!yo'));
-	t.false(fn.test('$yo', {prefix: '!'}));
+	t.true(defaultTest('$yo'));
+	t.false(defaultTest('!yo'));
+
+	const customTest = fn.tester({prefix: '!'});
+
+	t.true(customTest('!yo'));
+	t.false(customTest('$yo'));
 });
 
-test('fn.matches()', t => {
-	const res = fn.matches('$some $stuff');
+test('fn.matcher()', t => {
+	const res = fn.matcher()('$some $stuff');
 
 	t.same(res, ['some', 'stuff']);
 });


### PR DESCRIPTION
This changes make the module expose `test` and `mathes` methods that are supposed to improve interaction with other tools.

It should help to cover the case of #1 i.e. making variable parsing consistent between plugins.

@benjie sorry for the delay, please check if I missed something imporant!
